### PR TITLE
Move to build action v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Build
-        uses: proofscape/pfsc-repo-build-action@v1
+        uses: proofscape/pfsc-repo-build-action@v2.0.0-a0
         with:
           content-vers: ${{inputs.content-vers || 'WIP' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Build
-        uses: proofscape/pfsc-repo-build-action@v2.0.0-a0
+        uses: proofscape/pfsc-repo-build-action@v2
         with:
           content-vers: ${{inputs.content-vers || 'WIP' }}
-          clean: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,3 +16,4 @@ jobs:
         uses: proofscape/pfsc-repo-build-action@v2.0.0-a0
         with:
           content-vers: ${{inputs.content-vers || 'WIP' }}
+          clean: true


### PR DESCRIPTION
Upgrade to `v2` of `pfsc-repo-build-action` in our test workflow.